### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # Build-Your-Own-RESTful-API
 
+## collection.update is deprecated.
+```
+// Replace this:
+MyModel.update({ foo: 'bar' }, { answer: 42 });
+// With this:
+MyModel.updateOne({ foo: 'bar' }, { answer: 42 });
+
+// If you use `overwrite: true`, you should use `replaceOne()` instead:
+MyModel.update(filter, update, { overwrite: true });
+// Replace with this:
+MyModel.replaceOne(filter, update);
+
+// If you use `multi: true`, you should use `updateMany()` instead:
+MyModel.update(filter, update, { multi: true });
+// Replace with this:
+MyModel.updateMany(filter, update);
+
+```
+
 ## Example Documents
 ```
 {


### PR DESCRIPTION
Like remove(), the update() function is deprecated in favor of the more explicit updateOne(), updateMany(), and replaceOne() functions. You should replace update() with updateOne(), unless you use the multi or overwrite options.


Hope this is helpful :)